### PR TITLE
add support to prepend prefix in api paths

### DIFF
--- a/protoc-gen-coredge-sdk/internal/gengateway/generator.go
+++ b/protoc-gen-coredge-sdk/internal/gengateway/generator.go
@@ -24,11 +24,12 @@ type generator struct {
 	registerFuncSuffix string
 	allowPatchFeature  bool
 	standalone         bool
+	pathPrefix         string
 }
 
 // New returns a new generator which generates grpc gateway files.
 func New(reg *descriptor.Registry, useRequestContext bool, registerFuncSuffix string,
-	allowPatchFeature, standalone bool) gen.Generator {
+	allowPatchFeature, standalone bool, pathPrefix string) gen.Generator {
 	var imports []descriptor.GoPackage
 	for _, pkgpath := range []string{
 		"io",
@@ -61,6 +62,7 @@ func New(reg *descriptor.Registry, useRequestContext bool, registerFuncSuffix st
 		registerFuncSuffix: registerFuncSuffix,
 		allowPatchFeature:  allowPatchFeature,
 		standalone:         standalone,
+		pathPrefix:         pathPrefix,
 	}
 }
 
@@ -123,6 +125,7 @@ func (g *generator) generate(file *descriptor.File) (string, error) {
 		UseRequestContext:  g.useRequestContext,
 		RegisterFuncSuffix: g.registerFuncSuffix,
 		AllowPatchFeature:  g.allowPatchFeature,
+		PathPrefix:         g.pathPrefix,
 	}
 	if g.reg != nil {
 		params.OmitPackageDoc = g.reg.GetOmitPackageDoc()

--- a/protoc-gen-coredge-sdk/main.go
+++ b/protoc-gen-coredge-sdk/main.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	pathPrefix                 = flag.String("path_prefix", "", "The prefix used for the paths in the URLs of the REST APIs exposed by a microservice.")
 	registerFuncSuffix         = flag.String("register_func_suffix", "Handler", "used to construct names of generated Register*<Suffix> methods.")
 	useRequestContext          = flag.Bool("request_context", true, "determine whether to use http.Request's context or not")
 	allowDeleteBody            = flag.Bool("allow_delete_body", false, "unless set, HTTP DELETE methods may not have a body")
@@ -80,7 +81,7 @@ func main() {
 
 		codegenerator.SetSupportedFeaturesOnPluginGen(gen)
 
-		generator := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *allowPatchFeature, *standalone)
+		generator := gengateway.New(reg, *useRequestContext, *registerFuncSuffix, *allowPatchFeature, *standalone, *pathPrefix)
 
 		if grpclog.V(1) {
 			grpclog.Infof("Parsing code generator request")


### PR DESCRIPTION
This Commit adds prefix filed in generated clients. this prefix field is then added as prefix to sub-urls before making request. The Orbiter server requires a prefix in the URL paths of REST requests to identify which microservice the request should be redirected to.

Jira ID: COMPASS-4262